### PR TITLE
Ensure dt>0 in PySim.replay_by_time(), closes #30

### DIFF
--- a/billiards.pyx
+++ b/billiards.pyx
@@ -1229,7 +1229,16 @@ cdef class PySim():
             - 'R' - radius
             - 'I' - moment of inertia
         
+        Raises
+        ------
+        ValueError
+            Raised if dt is less than or equal to zero
+        
         """
+
+        # Ensure dt is greater than zero
+        if dt<=0.0:
+            raise ValueError(f"dt must be greater than zero. dt was {dt}")
 
         current_state = self.initial_state
 

--- a/testing/test_billiards.py
+++ b/testing/test_billiards.py
@@ -1510,8 +1510,17 @@ class Test_PySim(unittest.TestCase):
         
         with self.assertRaises(ValueError) as _:
             sim.e_t = 1.1
+    
+    def test_replay_by_time_reject_negative_dt(self):
+        """Tests PySim.replay_by_time() rejects dt<=0.0"""
 
+        sim = create_20_disc_sim(1, 1, e_t=-1.0, g=[0.0, 0.0])  # Set e_t for smooth discs
 
+        s = sim['s']
 
-
+        with self.assertRaises(ValueError) as _:
+            next(s.replay_by_time(0.0))  # generators don't execute until next is called
+        
+        with self.assertRaises(ValueError) as _:
+            next(s.replay_by_time(-1.0))
 


### PR DESCRIPTION
- Ensure dt>0 in PySim.replay_by_time()
- Add test