### PR TITLE
46 prevent adding discs/walls after the simulation has started

### DIFF
--- a/billiards.pyx
+++ b/billiards.pyx
@@ -586,9 +586,8 @@ cdef class PySim():
 
         cdef Vec2D v_start = Vec2D(start[0], start[1])
         cdef Vec2D v_end = Vec2D(end[0], end[1])
-        cdef Wall w = Wall(v_start, v_end)
 
-        self.s.walls.push_back(w)
+        self.s.add_wall(v_start, v_end)
 
     def add_box_walls(self, bottom_left, top_right):
         """

--- a/cpp/billiards/Sim.cpp
+++ b/cpp/billiards/Sim.cpp
@@ -272,6 +272,15 @@ void Sim::add_disc(const Vec2D& pos, const Vec2D& v, double w, double m, double 
 	add_time_to_heap(disc_ind);
 }
 
+void Sim::add_wall(const Vec2D& start, const Vec2D& end)
+{
+	// Check the simulation has not started
+	if (sim_has_started)
+		throw std::runtime_error("Cannot add wall to simulation once advance() has been called.");	
+
+	walls.emplace_back(start, end);
+}
+
 double Sim::get_e_n() const
 {
 	return e_n;

--- a/cpp/billiards/Sim.cpp
+++ b/cpp/billiards/Sim.cpp
@@ -75,6 +75,8 @@ Sim::Sim(Vec2D bottom_left, Vec2D top_right, size_t N, size_t M)
 
 void Sim::advance(size_t max_iterations, double max_t, bool record_events)
 {
+	sim_has_started = true;
+
 	// Implements the algorithm described in (Lubachevsky 1991)
 
 	size_t current_it{ 0 };
@@ -199,6 +201,10 @@ void Sim::advance(size_t max_iterations, double max_t, bool record_events)
 
 void Sim::add_disc(const Vec2D& pos, const Vec2D& v, double w, double m, double R, double I)
 {
+	// Check the simulation has not started
+	if (sim_has_started)
+		throw std::runtime_error("Cannot add disc to simulation once advance() has been called.");	
+
 	// Check disc is within simulation bounds
 	double left, right, top, bottom;
 

--- a/cpp/billiards/Sim.h
+++ b/cpp/billiards/Sim.h
@@ -71,6 +71,9 @@ public:
 	// Adds a disc to the simulation. Should not be called after the simulation has started
 	void add_disc(const Vec2D& pos, const Vec2D& v, double w, double m, double R, double I);
 
+	// Adds a wall to the simulation. Should not be called after the simulation has started
+	void add_wall(const Vec2D& start, const Vec2D& end);
+
 	// Getter/setter methods for coefficients of restitution
 
 	double get_e_n() const;

--- a/cpp/billiards/Sim.h
+++ b/cpp/billiards/Sim.h
@@ -58,6 +58,9 @@ public:
 
 	double current_time{ 0.0 };
 
+	// gives whether advance() has been called or not
+	bool sim_has_started{ false };
+
 	// N and M are the number of sectors the simulation should be split up into in the 
 	// horizontal and vertical directions respectively
 	Sim(Vec2D bottom_left, Vec2D top_right, size_t N=1, size_t M=1);

--- a/cython_header.pxd
+++ b/cython_header.pxd
@@ -112,6 +112,7 @@ cdef extern from "Sim.h":
 
         void advance(size_t, double, bool) except+
         void add_disc(Vec2D pos, Vec2D v, double w, double m, double R, double I) except+
+        void add_wall(Vec2D start, Vec2D end) except+
 
         # Getter setter methods for coefficients of normal/tangential restitution,
         # acceleration due to gravity vector

--- a/testing/test_billiards.py
+++ b/testing/test_billiards.py
@@ -1346,6 +1346,31 @@ class Test_PySim(unittest.TestCase):
         with self.assertRaises(RuntimeError) as _:
             s.add_disc(pos+3.0, v, m, R)
 
+    def test_reject_add_wall_after_sim_started(self):
+        """Tests walls can't be added after advance() is called
+        """
+
+        L = 10.0  # Width/height of simulation box
+
+        bottom_left = [0.0, 0.0]
+        top_right = [L, L]
+
+        # Disc properties
+        pos = np.array([L/2, L/2])
+        v = [0.0, 0.0]
+        m = 2.0
+        R = 1.0
+
+        s = bl.PySim(bottom_left, top_right, 1, 1)
+
+        s.add_disc(pos, v, m, R)
+        s.add_wall([0.0, 0.0], [L, L])
+
+        s.advance(5, 100.0, True)
+
+        with self.assertRaises(RuntimeError) as _:
+            s.add_wall([0.0, L], [L, 0.0])
+
         
     def test_reject_invalid_bounds(self):
         """

--- a/testing/test_billiards.py
+++ b/testing/test_billiards.py
@@ -1321,6 +1321,31 @@ class Test_PySim(unittest.TestCase):
 
         # This should be allowed
         s.add_disc(pos, v, m, R, I=m*R**2 / 4)
+    
+    def test_reject_add_disc_after_sim_started(self):
+        """Tests discs can't be added after advance() is called
+        """
+
+        L = 10.0  # Width/height of simulation box
+
+        bottom_left = [0.0, 0.0]
+        top_right = [L, L]
+
+        # Disc properties
+        pos = np.array([L/2, L/2])
+        v = [0.0, 0.0]
+        m = 2.0
+        R = 1.0
+
+        s = bl.PySim(bottom_left, top_right, 1, 1)
+
+        s.add_disc(pos, v, m, R)
+
+        s.advance(5, 100.0, True)
+
+        with self.assertRaises(RuntimeError) as _:
+            s.add_disc(pos+3.0, v, m, R)
+
         
     def test_reject_invalid_bounds(self):
         """


### PR DESCRIPTION
- Prevent adding discs/walls after the simulation has started, prevents issues with scheduling